### PR TITLE
Bugfix: The retina images were never served if the cookie was set before

### DIFF
--- a/vendor/assets/javascripts/clear_eyes.js
+++ b/vendor/assets/javascripts/clear_eyes.js
@@ -1,4 +1,5 @@
-if (document.cookie == "") {
-  document.cookie = 'devicePixelRatio = ' + window.devicePixelRatio;
-  if (document.cookie != "devicePixelRatio=1") window.location.reload();
+if (document.cookie.indexOf('devicePixelRatio') == -1) {
+  var ratio = (window.devicePixelRatio !== undefined ? window.devicePixelRatio : 1);
+  document.cookie = 'devicePixelRatio=' + ratio + (document.cookie != "" ? "; " + document.cookie : "");
+  if (ratio > 1) window.location.reload();
 }


### PR DESCRIPTION
The JS only checked and stored window.devicePixelRatio if the cookie was empty. So if the cookie was set before (e.g. through Google Analytics) the check never occurred and retina images were never served.
