### PR TITLE
Remove rmagick from gemspec to simplify prod environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ There's a rake for that! You only need to create one image (the Retina one).
 
 Running this: ```rake clear_eyes:convert``` will convert create non-retina images from the images in app/assets/images. It's even take care of the file names! Pretty cool right? So, ```my_awesome_image@2x.jpg``` will automatically be copied, downsized and named ```my_awesome_image.jpg```.
 
+**NOTE** rmagick "~> 2.13.1" must be added to your Gemfile for this to work. It is not included by default in order to avoid adding rmagick to your production environment.
+
 You can thank me later.
 
 ## Contributing

--- a/clear_eyes.gemspec
+++ b/clear_eyes.gemspec
@@ -15,5 +15,4 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib", "vendor"]
   gem.version       = ClearEyes::VERSION
   gem.add_dependency "railties", ">= 4.0"
-  gem.add_dependency "rmagick", "~> 2.13.1"
 end


### PR DESCRIPTION
Love the rake task, but I don't love having to get rmagick installed in my prod environment. So I removed it from the gemspec, and added a note in the readme to tell users to add it to the development group if they want to use the rake task.

Is there a better way to do this?